### PR TITLE
Remove the criteria for acceptance testing from Dragon

### DIFF
--- a/core-skills/tdd/README.md
+++ b/core-skills/tdd/README.md
@@ -105,9 +105,6 @@ You will need to TDD a feature which interacts with a remote service of your cho
 
 Review and refactor a preprepared test suite to improve performance.
 
-- Can write an acceptance test around an existing feature.
-  - Required - Write an acceptance test around a feature of an existing application which verifies the feature works as intended.
-
 - Can identify smells within somebody else's code.
   - Required - Can list three valid smells per the invigilator's guide.
 


### PR DESCRIPTION
While Richard and I are keen to have the concept of acceptance testing
included within the testing core skill we can't currently see a way to
include it within the 3 badges.

We can reconsider this at a later date, possibly by introducing the
concept of a new badge.