### PR TITLE
Add the React Fox Core Skill

### DIFF
--- a/core-skills/web-application-development-with-react/README.md
+++ b/core-skills/web-application-development-with-react/README.md
@@ -33,6 +33,12 @@ Each section of the mark scheme will be separated into their respective categori
 Example answers for the questions be found on the hidden marking guide, however we do not require exact matches. It 
 is up to the assessor to determine whether or not the candidate has adequetly answered the question. 
 
+### The Application
+
+Build an app which communicates with an API, either one you write your own (you dont need to implement the API)
+or one that already exists, see: https://github.com/toddmotto/public-apis
+
+
 ## Mark Scheme
 
 ### Hedgehog
@@ -42,49 +48,60 @@ Learning the fundamentals - How not to hurt yourself with React
 #### Application
 
 The candidate has:
-- [ ] Has created an application that is independent of the node install on the candidates machine 
-- [ ] Has a make recipe for serve, which runs the application in development mode
-- [ ] Has a make recipe for test, which runs the tests for the application
-- [ ] Has a sandbox environment which allows them to quickly prototype components
-- [ ] Has the ablity to hot-reload based on changes 
-- [ ] Has a failing test that appears when running make test
+- Has created an application that is independent of the node install on the candidates machine 
+- Has a make recipe for serve, which runs the application in development mode
+- Has a make recipe for test, which runs the tests for the application
+- Has a sandbox environment which allows them to quickly prototype components
+- Has the ablity to hot-reload based on changes 
+- Has a failing test that appears when running make test
 
 #### Understanding
 
 The candidate can describe:
 
-- [ ] Situations in which using React would be a benefit
-- [ ] What a React component is
-- [ ] What are props within a component
-- [ ] What is state within a component
-- [ ] What children are within a component
-- [ ] How React allows you to respond to user events
-- [ ] One approach to styling react components
-- [ ] The component lifecyle
-- [ ] An approach to managing Application state
+- Situations in which using React would be a benefit
+- What a React component is
+- What are props within a component
+- What is state within a component
+- What children are within a component
+- How React allows you to respond to user events
+- One approach to styling react components
+- The component lifecyle
+- An approach to managing Application state
 
 ### Fox
 
-- Components
-  - The candidate has created components demonstrating the following:
-    - [ ] A component without any props or state
-    - [ ] The use of props
-    - [ ] The use of state
-    - [ ] The use of children
-    - [ ] Responding to user events
-    - [ ] Styling components  
-- Architecture
-  - The candidate can explain the following;
-    - [ ] Communicating with APIs
-    - [ ] Division of business logic, domain, rendering and state
-    - [ ] How to test component rendering
-    - [ ] How to test business logic
+Getting crafty with React - Creating some components for your users
 
-**Coming Soon - Fox is intended to test ability to write simple components and understanding
-of architecture & testing strategies for complex applications**
-
+- The candidate has created an application which contains:
+  - A component without any props or state
+  - A component which renders differently based on the following prop types being passed in:
+    - A boolean
+    - A string
+    - A function
+    - The `children` prop
+  - An appropriate use of the `key` prop
+  - A component which renders differently based on state changes
+  - A component which changes state in response to an onClick event
+  - A component which has been styled without global styles
 
 ### Owl
+
+**Coming soon - Notes for the future**
+
+Owl is intended to demonstrate the ability to write tests for your application, and to integrate with external services in
+order to make a more feature rich application.
+
+Will also test componentDidMount calling APIs
+
+Forms for posting
+
+- Architecture
+  - The candidate can explain the following;
+    - Communicating with APIs
+    - Division of business logic, domain, rendering and state
+    - How to test component rendering
+    - How to test business logic
 
 **Coming Soon - Owl is intended to demonstrate ability to put understanding of advanced architecture
 principles and testing strategy into practice**

--- a/core-skills/web-application-development-with-react/README.md
+++ b/core-skills/web-application-development-with-react/README.md
@@ -11,7 +11,7 @@ This course is intended to guide learning to a level where you could write and c
 3. Can describe the different parts of the Javascript ecosystem (e.g. NPM, Webpack, etc)
 4. Can demonstrate using TDD on business logic within a React code base
 5. Can demonstrate strategies to achieve clear separation of business logic and display logic
-with React components
+   with React components
 6. Can demonstrate applying sensible styling to React components
 7. Can demonstrate strategies and tools to run tests against an API within a React application
 
@@ -30,14 +30,13 @@ during Learn Tech and brought along with you, and the second being questions to 
 
 Each section of the mark scheme will be separated into their respective categories.
 
-Example answers for the questions be found on the hidden marking guide, however we do not require exact matches. It 
-is up to the assessor to determine whether or not the candidate has adequetly answered the question. 
+Example answers for the questions be found on the hidden marking guide, however we do not require exact matches. It
+is up to the assessor to determine whether or not the candidate has adequetly answered the question.
 
 ### The Application
 
 Build an app which communicates with an API, either one you write your own (you dont need to implement the API)
 or one that already exists, see: https://github.com/toddmotto/public-apis
-
 
 ## Mark Scheme
 
@@ -48,11 +47,12 @@ Learning the fundamentals - How not to hurt yourself with React
 #### Application
 
 The candidate has:
-- Has created an application that is independent of the node install on the candidates machine 
+
+- Has created an application that is independent of the node install on the candidates machine
 - Has a make recipe for serve, which runs the application in development mode
 - Has a make recipe for test, which runs the tests for the application
 - Has a sandbox environment which allows them to quickly prototype components
-- Has the ablity to hot-reload based on changes 
+- Has the ablity to hot-reload based on changes
 - Has a failing test that appears when running make test
 
 #### Understanding
@@ -63,10 +63,11 @@ The candidate can describe:
 - What a React component is
 - What are props within a component
 - What is state within a component
-- What children are within a component
+- What `props.children` refers to
 - How React allows you to respond to user events
 - One approach to styling react components
-- The component lifecyle
+- What causes a component to rerender?
+- Describe a lifecycle method that you can hook into and perform actions on
 - An approach to managing Application state
 
 ### Fox


### PR DESCRIPTION
We discussed pulling testing into this part of the core skill - However as this is a part we've historically struggled with in React, we decided to focus on ensuring people could write React components without the overhead of also having to write tests for these components.

Once someone has achieved Fox, we would expect them to know how a React component is structured/written so that they can then go ahead and TDD a component within Owl.

I think as we go forward we plan to revisit these and see whether or not things could be shifted, e.g. Fox focused mainly around testing, and some of the basic components put into the Hedgehog criteria