### PR TITLE
Infrastructure Core Skill: Level 1

### DIFF
--- a/core-skills/infrastructure/README.md
+++ b/core-skills/infrastructure/README.md
@@ -1,0 +1,1 @@
+# Infrastructure

--- a/core-skills/infrastructure/README.md
+++ b/core-skills/infrastructure/README.md
@@ -15,3 +15,30 @@ Demonstrate understanding of:
 3. Principle of Least Privilege
 4. Zero-downtime deployments
 
+## Marking Scheme
+
+### Level 1
+
+#### Brief
+
+#### Assessment
+
+#### Practical
+
+
+### Level 2
+
+#### Brief
+
+#### Assessment
+
+#### Practical
+
+### Level 3
+
+#### Brief
+
+#### Assessment
+
+#### Practical
+

--- a/core-skills/infrastructure/README.md
+++ b/core-skills/infrastructure/README.md
@@ -37,8 +37,9 @@ You will be provided a Linux Container Image, though you can use your own if you
 - Run the image with your choice of IaaS.
 - Make the service highly available
 - Draw a diagram of your infrastructure
-- Demonstrate that you can remove an instance without causing any downtime.
-  A [script][downtime-script] has been provided for your convenience
+- Demonstrate that you can remove an instance, and your infrastructure will self heal
+- Demonstrate that you can roll out a new deployment without causing any downtime.
+  Use the provided [downtime detection script][downtime-script].
 
 
 ### Level 2

--- a/core-skills/infrastructure/README.md
+++ b/core-skills/infrastructure/README.md
@@ -15,22 +15,37 @@ Demonstrate understanding of:
 3. Principle of Least Privilege
 4. Zero-downtime deployments
 
-## Marking Scheme
+## Assessments
 
 ### Level 1
 
 #### Brief
 
-#### Assessment
+Be able to set up a highly available, internet facing web application.
+
+#### Theory
+
+1. What are IaaS, PaaS, and FaaS?
+   1. For each of these; Discuss a scenario where the technology is appropriate
+   2. For each of these; Discuss a scenario where the technology is not appropriate
+2. What is the importance of having a highly available service?
 
 #### Practical
+
+You will be provided a Linux Container Image, though you can use your own if you wish.
+
+- Run the image with your choice of IaaS.
+- Make the service highly available
+- Draw a diagram of your infrastructure
+- Demonstrate that you can remove an instance without causing any downtime.
+  A [script][downtime-script] has been provided for your convenience
 
 
 ### Level 2
 
 #### Brief
 
-#### Assessment
+#### Theory
 
 #### Practical
 
@@ -38,7 +53,26 @@ Demonstrate understanding of:
 
 #### Brief
 
-#### Assessment
+#### Theory
 
 #### Practical
 
+
+## Appendix
+
+### Downtime Script
+
+```sh
+target="<your endpoint>"
+while :; do
+ if (curl -m 1 "$target" &>/dev/null); then
+   printf '.'
+ else
+   echo "target is down"
+   break
+ fi
+ sleep 0.5
+done
+```
+
+[downtime-script]: #downtime-script

--- a/core-skills/infrastructure/README.md
+++ b/core-skills/infrastructure/README.md
@@ -57,6 +57,27 @@ You will be provided a Linux Container Image, though you can use your own if you
 
 #### Practical
 
+## Limitations
+
+### Provider requirements
+
+There are certain providers, usually PaaS only providers, that do not offer the
+functionality we require for testing people on all the above aspects.
+
+As such, we recommend avoiding solutions that hide:
+
+- load balancing
+- autoscaling
+- networking rules (routing, Firewalls)
+
+Providers that can definitely be used are:
+
+- AWS
+  - ECS with FARGATE is fine, though be prepared for increased theory work around deployment processes
+  - Lambda is not recommended, as it hides a lot of networking rules, autoscaling, and deployment processes
+  - Elastic Beanstalk is not allowed, as it does everything for you, but in a way that makes it hard to adapt after the fact.
+- Azure
+- GCP
 
 ## Appendix
 

--- a/core-skills/infrastructure/README.md
+++ b/core-skills/infrastructure/README.md
@@ -1,1 +1,17 @@
 # Infrastructure
+
+## Goal
+
+1. Increase the reliability of services
+2. Ensure compliance with international security standards
+3. Reduce the chance of knowledge silos developing within teams
+
+## Summary
+
+Demonstrate understanding of:
+
+1. Making a service Scalable
+2. Making a service Highly Available
+3. Principle of Least Privilege
+4. Zero-downtime deployments
+


### PR DESCRIPTION
Introduce Level 1 for the Infrastructure Core Skill.

**Why**

We are currently in a situation where we have only a few people confident in setting up and maintaining infrastructure.
This has led to knowledge silo's within teams.

When these knowledgeable people aren't available to a project, some fairly bad occurrences happen:
- Security is sacrificed to maintain a simpler system
- Inflexible PaaSs are utilised, which work for basic projects, but;
  - incur major technical debt when the time comes to expand the system
  - incur major monetary costs when it comes to scaling a service up

To combat this, we are releasing the Level 1 assessment of the Infrastructure Core Skill to set a strategy for upskilling everyone with the basics of Infrastructure.

Level 2/3, and resourcing are to follow over the coming weeks, however Level 1 should be considered in a state to get basic knowledge of different types of hosting solutions, networking rules, and High Availability in a vendor neutral manner.