### PR TITLE
Minor tweaks to tech page

### DIFF
--- a/_includes/digital_element_header.html
+++ b/_includes/digital_element_header.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="offset-lg-1 col-lg-10">
         <h1 class='mt-0' markdown="1">{{ include.title }}</h1>
-        <h4 class='lead' markdown="1">{{ include.text }}</h4>
+        <p class='lead' markdown="1">{{ include.text }}</p>
       </div>
     </div>
   </div>

--- a/technology/README.md
+++ b/technology/README.md
@@ -18,31 +18,39 @@ Use these resources to build reliable and maintainable digital services, APIs an
 <div class="row">
   <div class="col-sm">
     <div class="card-body card-border">
-      <h3 class="card-title mt-0">Katas</h3>
-      <p class="card-text">Develop your programming skills using these solo training exercises; Ideal for those looking to improve their test-driven development</p>
-      <a href="/katas" class="btn btn-success">Learn more</a>
+      <h3 class="card-title mt-0">Tutorials</h3>
+      <p class="card-text">
+        Learn practical skills such as setting up your development environment, debugging stacktraces and refactoring your code.
+      </p>
+      <a href="/tutorials" class="btn btn-success">Learn more</a>
     </div>
   </div>
   <div class="col-sm">
     <div class="card-body card-border">
-      <h3 class="card-title mt-0">Tutorials</h3>
-      <p class="card-text">Learn practical skills such as setting up your development environment, debugging stacktraces and refactoring your code</p>
-      <a href="/tutorials" class="btn btn-success">Learn more</a>
+      <h3 class="card-title mt-0">Videos</h3>
+      <p class="card-text">
+        Watch our in-depth video guides to get to grips with disciplines such as clean architecture and test-driven development.
+      </p>
+      <a href="/videos" class="btn btn-success">Learn more</a>
     </div>
   </div>
 </div>
 <div class="row">
   <div class="col-sm">
     <div class="card-body card-border">
-      <h3 class="card-title mt-0">Videos</h3>
-      <p class="card-text">Watch our in-depth video guides to get to grips with disciplines such as clean architecture and test-driven development</p>
-      <a href="/videos" class="btn btn-success">Learn more</a>
+      <h3 class="card-title mt-0">Katas</h3>
+      <p class="card-text">
+        Develop your programming skills using these solo training exercises; Ideal for those looking to improve their test-driven development.
+      </p>
+      <a href="/katas" class="btn btn-success">Learn more</a>
     </div>
   </div>
   <div class="col-sm">
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Koans</h3>
-      <p class="card-text">Gain a deep understanding of a wide range of programming languages in a gamified testing environment</p>
+      <p class="card-text">
+        Gain a deep understanding of a wide range of programming languages in a gamified testing environment.
+      </p>
       <a href="/koans" class="btn btn-success">Learn more</a>
     </div>
   </div>
@@ -59,7 +67,9 @@ Use these resources to build reliable and maintainable digital services, APIs an
   <div class="col-sm">
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Test-driven development</h3>
-      <p class="card-text">Build reliable and maintainable applications using the discipline of TDD.</p>
+      <p class="card-text">
+        Build reliable and maintainable applications using the discipline of TDD.
+      </p>
       <a href="/core-skills/tdd" class="btn btn-success">Learn more</a>
     </div>
   </div>
@@ -67,7 +77,9 @@ Use these resources to build reliable and maintainable digital services, APIs an
   <div class="col-sm">
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Infrastructure</h3>
-      <p class="card-text">Use code to describe and build your cloud infrastructure in a repeatable and scalable way</p>
+      <p class="card-text">
+        Use code to describe and build your cloud infrastructure in a repeatable and scalable way.
+      </p>
       <a href="/core-skills/infrastructure" class="btn btn-success">Learn more</a>
     </div>
   </div>
@@ -75,7 +87,9 @@ Use these resources to build reliable and maintainable digital services, APIs an
   <div class="col-sm">
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Frontend development</h3>
-      <p class="card-text">Learn the fundamental building blocks of the web, modern HTML and CSS</p>
+      <p class="card-text">
+        Learn the fundamental building blocks of the web, modern HTML and CSS.
+      </p>
       <a href="/core-skills/frontend-development" class="btn btn-success">Learn more</a>
     </div>
   </div>
@@ -92,21 +106,27 @@ Use these resources to build reliable and maintainable digital services, APIs an
   <div class="col-sm">
     <div class="card-body card-border">
       <h3 class="card-title mt-0">React</h3>
-      <p class="card-text">Develop applications using a testable component-based architecture</p>
+      <p class="card-text">
+        Develop applications using a testable component-based architecture.
+      </p>
       <a href="/core-skills/react" class="btn btn-success">Learn more</a>
     </div>
   </div>
   <div class="col-sm">
     <div class="card-body card-border">
       <h3 class="card-title mt-0">C#/.NET Core</h3>
-      <p class="card-text">Craft APIs using Microsoft’s open source language and framework</p>
+      <p class="card-text">
+        Craft APIs using Microsoft’s open source language and framework.
+      </p>
       <a href="/additional-skills/c-sharp-and-dotnet" class="btn btn-success">Learn more</a>
     </div>
   </div>
   <div class="col-sm">
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Git</h3>
-      <p class="card-text">Manage your source code using the most popular version control system</p>
+      <p class="card-text">
+        Manage your source code using the most popular version control system.
+      </p>
       <a href="/additional-skills/git" class="btn btn-success">Learn more</a>
     </div>
   </div>

--- a/technology/README.md
+++ b/technology/README.md
@@ -49,7 +49,7 @@ Use these resources to build reliable and maintainable digital services, APIs an
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Koans</h3>
       <p class="card-text">
-        Gain a deep understanding of a wide range of programming languages in a gamified testing environment.
+        Gain a deep understanding of a wide range of programming languages in an enjoyable practice environment.
       </p>
       <a href="/koans" class="btn btn-success">Learn more</a>
     </div>


### PR DESCRIPTION
What: Reorder 'hone your skills', remove h4 tag in jumbotron and rename  
Why: Visual consistency
![image](https://user-images.githubusercontent.com/41294831/59860511-e17cfe80-9376-11e9-816e-4ef70f4628fe.png)
