### PR TITLE
Patch legacy markdown

### DIFF
--- a/_includes/legacy_markdown_container.html
+++ b/_includes/legacy_markdown_container.html
@@ -1,0 +1,3 @@
+<main class="container mt-10" markdown="1">
+{{ include.content }}
+</main>

--- a/additional-skills/c-sharp-and-dotnet/README.md
+++ b/additional-skills/c-sharp-and-dotnet/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # C# and .NET Core
 
 ## Who is this skill for?
@@ -83,3 +84,5 @@ Eagle is a space to demonstrate a deeper understanding of OO programming and imp
  - Can demonstrate use of delegates
 
 Expected deliverable - A C# application that showcases an understanding of all the above points (this is intentionally open ended to allow for some flexing! Refer to the marking guide and look for clean, SOLID code with good testing strategies).
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/additional-skills/git/README.md
+++ b/additional-skills/git/README.md
@@ -1,8 +1,9 @@
+{% capture content %}
 # Git + GitHub
 
 All sections are required.
 
-## Initializing 
+## Initializing
 
 * Demonstrate initializing a new git repository.
 * Demonstrate creating an empty root commit.
@@ -16,7 +17,7 @@ All sections are required.
 * Demonstrate committing a subset of changed files using staged and unstaged files.
 * Demonstrate using stash and stash pop.
 
-## Commits, refs, and labels 
+## Commits, refs, and labels
 
 * Can explain what a commit ref is.
 * Can explain what a tag is.
@@ -53,7 +54,7 @@ All sections are required.
 * Demonstrate performing an interactive rebase of a branch.
   * Demonstrate using all possible rebase options.
 
-## Cherry Picking 
+## Cherry Picking
 
 * Demonstrate cherry picking a single commit from another branch.
 * Demonstrate recording the original commit hash in the commit message.
@@ -111,5 +112,5 @@ All sections are required.
 * Demonstrate writing commit messages that explain "why" and "what".
 * Demonstrate giving commit messages short and long descriptions using a text editor.
 * Demonstrate changing the default text editor that git uses.
-
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/articles/README.md
+++ b/articles/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Articles
 
 Alphabetically sorted list of articles on various topics.
@@ -5,3 +6,5 @@ Alphabetically sorted list of articles on various topics.
 ## C
 
  - [Cost of Delay](./cost-of-delay.md)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/articles/cost-of-delay.md
+++ b/articles/cost-of-delay.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Cost of Delay
 
 **Counterpoint:** [Late Start Benefits](./late-start-benefits.md)
@@ -21,7 +22,7 @@ It is the difference between the value that would be available if a work item we
 
 In reality, it is rare to be able to calculate both the Value and Cost (and therefore also Cost of Delay), so we estimate them.
 
-Teams can use Cost of Delay estimation to prioritise and schedule work items as part of [WSJF](./weighted-shortest-job-first.md) priortisation. 
+Teams can use Cost of Delay estimation to prioritise and schedule work items as part of [WSJF](./weighted-shortest-job-first.md) priortisation.
 
 There are a number of standard plots to Cost vs Time on a graph, here are some described with examples.
 
@@ -56,4 +57,5 @@ Mostly flat linear cost, but a possibility of an extreme cost in future.
 Example: You have the capability to innovate new technology Y, you do not, a competitor releases Y which impacts your revenue.
 
 Potential Course of Action: Prioritise an amount of R&D work.
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/README.md
+++ b/core-skills/frontend-development/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Frontend web development [HTML/CSS]
 
 ## Aim
@@ -100,7 +101,5 @@ While presenting your page, you should be able to explain the following:
 - How did you keep your form accessible whilst applying custom styling?
 - If you had to stop flash of unstyled content (FOUC) how would you have gone about it?
 - If a customer requested the page structure to remain consistant while the page loaded how would you do that?
-
-
-
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/cross-browser-testing.md
+++ b/core-skills/frontend-development/resources/cross-browser-testing.md
@@ -1,10 +1,11 @@
+{% capture content %}
 # Cross Browser Testing
 
 A software engineer should be able to validate their front end across multiple browsers and devices in order to ensure that their HTML/CSS looks correct in many browsers.
 
 An engineer should use tools like [caniuse.com](https://caniuse.com/) to ensure the CSS properties they want to use will be supported by all their target browsers, before even cutting some CSS.
 
-Often an engineer will be missing some of the browsers they need to test against [Mainly IE] for this they'd install a Virtual Machine (VM). Microsoft make their VMs available on [modern.ie](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/). 
+Often an engineer will be missing some of the browsers they need to test against [Mainly IE] for this they'd install a Virtual Machine (VM). Microsoft make their VMs available on [modern.ie](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/).
 
 An easy approach is to use a SaaS tool such a [BrowserStack](https://www.browserstack.com) which allows testing on a myriad of real devices and browsers, without requiring physical access to those devices or those browsers installed on your own machine.
 
@@ -32,3 +33,5 @@ While we should always strive to realise a Designer’s vision, there will be so
 When working closely with Designers, it is beneficial to help them understand the technical limitations of HTML & CSS. Often, for aspects of a design where perfect typography matters, a designer should be advised to provide SVG assets instead.
 
 Using the example of Typography an engineer should match the common sense things like `line-height`, `font-size`, `font-family`, there are some things they wont be able to control in a scenario where dynamic text is being used. Kerning is the best example of this. An engineer can broadly apply a `letter-spacing` to all the letters but doing this on a per letter basis is not scalable when the copy is liable to change.
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/css-architecture.md
+++ b/core-skills/frontend-development/resources/css-architecture.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # CSS Architecture
 
 A well-written set of stylesheets balance a number of factors including
@@ -64,8 +65,9 @@ Another criticism is that CSS frameworks allow you to do things their way, but p
 ## CSS Layout
 
 - https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout
-- https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Floats 
-- https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox 
-- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox 
+- https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Floats
+- https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox
+- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
 - https://css-tricks.com/snippets/css/a-guide-to-flexbox/
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/grids.md
+++ b/core-skills/frontend-development/resources/grids.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Grids
 
 Long gone are the days of table based layouts. Engineers use CSS to achieve basic to the most complex of page layouts.
@@ -12,11 +13,11 @@ Flexbox (including flex-direction for vertical layout considerations)
 
 Engineer can describe each of these and think of both positives and negatives for using each.
 
-Do we want to list some of the pros/cons that we think there might be? Not all, but some might be subjective. 
+Do we want to list some of the pros/cons that we think there might be? Not all, but some might be subjective.
 
 Floats will work well in all browsers as this has been around far longer. More complex though (potentially) to build your layout, with having to manage the floats and clears, and calculating various widths and heights manually.
 
-Flexbox will work well in modern browsers, but not in older ones. 
+Flexbox will work well in modern browsers, but not in older ones.
 
 If not using floats or flexbox, then you could use a grid layout system, such as Twitter Bootstrap.
 
@@ -30,3 +31,5 @@ Frameworks like Bootstrap are great, but sometimes you don’t need the kitchen 
 - [Basic Concepts of Flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
 - https://hacks.mozilla.org/2016/04/you-might-not-need-a-css-framework/
 - https://css-tricks.com/what-are-the-benefits-of-using-a-css-framework/
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/html-css-standards.md
+++ b/core-skills/frontend-development/resources/html-css-standards.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # HTML/CSS Standards
 
 ### Useful Tools
@@ -5,3 +6,5 @@
 - [WebHint](https://webhint.io/)
 - [SASS Lint](https://github.com/sasstools/sass-lint)
 - [HTML Lint](https://github.com/htmllint/htmllint)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/icons.md
+++ b/core-skills/frontend-development/resources/icons.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Icons
 
 ### Useful links
@@ -9,3 +10,5 @@
 ### Useful tools
 
 - [IcoMoon](https://icomoon.io/app/#/select)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/progressive-enhancement.md
+++ b/core-skills/frontend-development/resources/progressive-enhancement.md
@@ -1,6 +1,9 @@
+{% capture content %}
 # Progressive Enhancement
 
 ### Useful Links
 
 https://www.smashingmagazine.com/2009/04/progressive-enhancement-what-it-is-and-how-to-use-it/
 https://zurb.com/word/progressive-enhancement
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/responsive-design.md
+++ b/core-skills/frontend-development/resources/responsive-design.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Responsive Design
 
 ## What does it mean for a design to be 'responsive'?
@@ -39,3 +40,5 @@ Even if your site isn't heavily used on mobile right now, it's still worth consi
 Ethan Marcotte, coiner of the term "Responsive Design", [going into some detail about why it's important](https://alistapart.com/article/responsive-web-design).
 
 A [Government Digital Service blog post](https://gds.blog.gov.uk/2012/11/02/designing-for-different-devices) diving into how to use some of the techniques.
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/semantic-html.md
+++ b/core-skills/frontend-development/resources/semantic-html.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Semantic HTML
 
 ## What do we mean by 'Semantic'?
@@ -18,3 +19,5 @@ This is in contrast to markup that focuses on _presentation_ or _visual structur
 [This article](https://internetingishard.com/html-and-css/semantic-html/) has excellent examples of using the HTML5 semantic elements to produce more meaningful markup.
 
 Mozilla highlights [some of these new elements](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantic_elements), and has [references and tutorials around their use](https://developer.mozilla.org/en-US/docs/Web/HTML)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/seo.md
+++ b/core-skills/frontend-development/resources/seo.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # SEO
 
 ### Useful links
@@ -13,3 +14,5 @@
 ### Useful tools
 
 - https://search.google.com/structured-data/testing-tool/u/0/
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/web-accessibility.md
+++ b/core-skills/frontend-development/resources/web-accessibility.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Web Accessibility
 
 Accessibility
@@ -20,10 +21,12 @@ https://www.w3.org/WAI/gettingstarted/tips/developing
 https://dynomapper.com/blog/27-accessibility-testing/246-top-25-awesome-accessibility-testing-tools-for-websites
 http://code.viget.com/interactive-wcag/#role=&level=aa
 https://webaim.org/techniques/screenreader/
-http://www.color-blindness.com/coblis-color-blindness-simulator/ 
-https://www.wuhcag.com/wcag-checklist/ 
+http://www.color-blindness.com/coblis-color-blindness-simulator/
+https://www.wuhcag.com/wcag-checklist/
 https://www.marcozehe.de/2018/04/11/introducing-the-accessibility-inspector-in-the-firefox-developer-tools/
 
 ### The Standard
 
 https://www.w3.org/TR/wai-aria-1.1/
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/web-performance.md
+++ b/core-skills/frontend-development/resources/web-performance.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Web Performance
 
 ### Useful Links
@@ -12,3 +13,5 @@ https://www.cloudflare.com/learning/cdn/what-is-a-cdn/
 
 - https://imageoptim.com/online
 - https://imagecompressor.com/
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/web-typography.md
+++ b/core-skills/frontend-development/resources/web-typography.md
@@ -1,4 +1,7 @@
+{% capture content %}
 https://practicaltypography.com/straight-and-curly-quotes.html
 https://css-tricks.com/almanac/properties/f/font-feature-settings/
-http://pierrickcalvez.com/journal/a-five-minutes-guide-to-better-typography 
+http://pierrickcalvez.com/journal/a-five-minutes-guide-to-better-typography
 https://blog.marvelapp.com/body-text-small/
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/resources/working-with-photoshop.md
+++ b/core-skills/frontend-development/resources/working-with-photoshop.md
@@ -1,1 +1,4 @@
+{% capture content %}
 https://www.netguru.co/blog/photoshop-for-front-end-developers
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/frontend-development/rhino-assessee.md
+++ b/core-skills/frontend-development/rhino-assessee.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Rhino
 
 This assessment is in three parts, and can take up to three hours to complete.
@@ -43,3 +44,5 @@ These are the pages:
 [rhino-control-panel]: https://codepen.io/anon/pen/xNrZbW
 [rhino-click-heres]: https://codepen.io/anon/pen/WBOQLb
 [rhino-favourite-number]: https://codepen.io/anon/pen/YbQwbP
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/infrastructure/README.md
+++ b/core-skills/infrastructure/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Infrastructure
 
 ## Goal
@@ -98,3 +99,5 @@ done
 ```
 
 [downtime-script]: #downtime-script
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/react/README.md
+++ b/core-skills/react/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Web Application Development with React
 
 ## Aim
@@ -102,7 +103,7 @@ The candidate can describe:
 
 #### Getting wise with React - Integrating with remote services
 
-For this level you are expected to demonstrate the ability to test both your React 
+For this level you are expected to demonstrate the ability to test both your React
 components and any business logic used for communicating with remote services. It will
 also cover demonstrating best practice around the separation of business logic and UI
 logic.
@@ -124,7 +125,7 @@ The candidate should create a React application which satisfies the following.
   - Candidate should open the network tools and show that on form submission, a request is
     made by the browser to the API endpoint with a JSON encoded request body containing
     the form data.
-  - Candidate should walk assessor through tests which give maintainers confidence 
+  - Candidate should walk assessor through tests which give maintainers confidence
     that the component submits the data from the form to the API.
 - There should be a JS layer of indirection between the components and the API
   - Candidate should showcase standalone code which makes HTTP API requests, and tests which
@@ -133,3 +134,5 @@ The candidate should create a React application which satisfies the following.
 - The application should have component tests that have minimal coupling to markup they render.
   - Candidate should showcase their use of test specific html attributes in the test suite
     to achieve this.
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/react/fundamentals/README.md
+++ b/core-skills/react/fundamentals/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # React Fundamentals
 
 ## Summary
@@ -19,3 +20,5 @@ The first two sections of React's documentation, [JSX](https://reactjs.org/docs/
 - Handling Application State
   - To handle application state, you can either use something like the [React Context API](https://reactjs.org/docs/context.html),
     or look into a library such as [Redux](https://redux.js.org/introduction)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/react/setup.md
+++ b/core-skills/react/setup.md
@@ -1,6 +1,7 @@
+{% capture content %}
 # Setting up a React Project
 
-An Engineer with this core skill should be able to adequetly set up a React app in 
+An Engineer with this core skill should be able to adequetly set up a React app in
 an understandable and consistent manner.
 
 This would involve ensuring that the application can be run on any development machine,
@@ -9,9 +10,11 @@ have easy to run tests, and have a tool to aid in rapid prototyping of React com
 ### Reading material
 
 - Setup
-  - Setting up a React application can be done by hand, or by using 
+  - Setting up a React application can be done by hand, or by using
     [Create React App](https://github.com/facebook/create-react-app).
 - Testing
   - Coming soon
 - Prototyping React Components
   - A popular tool for this is [Storybook](https://storybook.js.org/)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/react/why-and-when.md
+++ b/core-skills/react/why-and-when.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # React - Why and when should I use it?
 
 An Engineer with this core skill should be able to make well informed decisions on whether or not
@@ -17,4 +18,5 @@ Things to think about when making the decision as to whether you should use Reac
 - Could your application benefit from selective reloading? I.e. does anything on the page need to react?
 - Is an existing customer development team already using React or NodeJS?
 - Does your application require a lot of DOM manipulation?
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/README.md
+++ b/core-skills/tdd/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Test Driven Development
 
 ## Summary
@@ -127,3 +128,5 @@ Review, refactor and improve an existing test suite.
   - Required - Does not change the production code before the test suite has been written.
   - Required - Demonstrates that the tests written allow developers to now safely refactor
     the production code.
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/discipline.md
+++ b/core-skills/tdd/discipline.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Demonstrating the Discipline
 
 An Engineer with this core skill must be able to demonstrate the ability to follow this discipline religiously.
@@ -20,6 +21,7 @@ Test-Driven Development is defined as a discipline with three rules:
 * Watches the failing test fail for right reason before writing production code
 * Writes only the minimum production code for a test to pass
 * Watches the passing test pass before moving onto refactoring
-* Refactors tests 
+* Refactors tests
 * Refactors production code
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/inappropriate.md
+++ b/core-skills/tdd/inappropriate.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Inappropriate TDD
 
 Graphical UIs are not suitable for TDD, they are usually defined in a markup language which can only be asserted for correctness by visually inspecting the rendered output.
@@ -9,3 +10,5 @@ State machines are configuration? Unit testing is still important, but the disci
 ## Marking Scheme
 
 Does not TDD markup.
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/performance.md
+++ b/core-skills/tdd/performance.md
@@ -1,11 +1,12 @@
+{% capture content %}
 # Test suite performance
 
-TDD relies on quick feedback cycles, 
-therefore Delivery Teams SHOULD make it possible to run 
-individual test suites within the ecosystem of an application 
-in under 30 seconds. Furthermore, it SHOULD be possible to run 
-the test suites of an entire application in under 5 minutes. 
-If this time limit is exceeded, 
+TDD relies on quick feedback cycles,
+therefore Delivery Teams SHOULD make it possible to run
+individual test suites within the ecosystem of an application
+in under 30 seconds. Furthermore, it SHOULD be possible to run
+the test suites of an entire application in under 5 minutes.
+If this time limit is exceeded,
 Delivery Teams SHOULD plan in effort to reduce test suite run times.
 
 Test suite performance is also an indicator of structural defects.
@@ -22,4 +23,5 @@ Test suite performance is also an indicator of structural defects.
 * Can identify structural defects that result in poor test suite performance.
 * Can identify that a test suite has poor test suite performance.
 * Can improve the performance of a slow test suite.
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/remote-services.md
+++ b/core-skills/tdd/remote-services.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Testing remote services
 
 A remote services is any cross process communication.  Let’s look at some examples:
@@ -8,7 +9,7 @@ A remote services is any cross process communication.  Let’s look at some exam
 
 In each case you want to be able to test that your communication with this remote service is set up correctly.  However your approach to each will likely be very different.
 
-### Running your tests against the service 
+### Running your tests against the service
 
 Your MySQL integration will usually be tested by running a copy of MySQL configured as closely to your production instance as possible.
 
@@ -36,7 +37,8 @@ Simulators are designed to allow you to easily configure how the remote service 
 
 ## Other Notes
 
-Strategies for other types of protocols e.g. AMQP, RADIUS, UDP-packets? 
+Strategies for other types of protocols e.g. AMQP, RADIUS, UDP-packets?
 
 Can explain what testing technique they would recommend to use for a remote service.
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/test-doubles.md
+++ b/core-skills/tdd/test-doubles.md
@@ -1,8 +1,9 @@
+{% capture content %}
 # Test Doubles
 
-At Made Tech we have adopted the Martin Fowler terminology of test doubles. 
+At Made Tech we have adopted the Martin Fowler terminology of test doubles.
 You can read an in depth explanation of test doubles on his website.  
-When using one of these test doubles you should be able to 
+When using one of these test doubles you should be able to
 explain which type you are using.
 
 * Dummy
@@ -22,4 +23,5 @@ explain which type you are using.
 * Can hand-write each of the test doubles.
 * Can explain when you should and shouldn’t use test doubles.
 * Can explain why minimizing the number of test doubles a single test case uses is desirable
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/triangulation.md
+++ b/core-skills/tdd/triangulation.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Triangulation
 
 Given a method f which has the production code as follows:
@@ -27,4 +28,5 @@ end
 * Can describe the situations where using triangulation helps improve test quality.
 * Can demonstrate examples of where they have used triangulation.
 * Can demonstrate triangulation when TDDing an example piece of code.
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/well-designed-tests.md
+++ b/core-skills/tdd/well-designed-tests.md
@@ -1,9 +1,10 @@
+{% capture content %}
 # Well-designed tests
 
 An Engineer with this core skill must be able to demonstrate good Test Design.
 
 * Avoid tight coupling between test code and production code
-* Conciseness of test suite 
+* Conciseness of test suite
 	* Maximizing behaviours tested by 1 suite
 	* Minimizing audiences that a test suite speaks to
 
@@ -17,7 +18,7 @@ Engineers that consider coupling avoid causing unnecessary code churn induced by
 
 If there is one call-site to a particular function then that function is easy to change
 
-It is desirable to ensure that the public interface of production code can evolve at a different rate to the test cases. 
+It is desirable to ensure that the public interface of production code can evolve at a different rate to the test cases.
 
 Conversely it is not desirable to need to update all your test cases to change the public interface
 
@@ -30,4 +31,5 @@ Conversely it is not desirable to need to update all your test cases to change t
 * Can identify smells within code they have written.
 * Can identify smells within somebody else's code.
 * Can explain the balancing act of achieving conciseness of a test suite
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/core-skills/tdd/well-written-tests.md
+++ b/core-skills/tdd/well-written-tests.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Well-written tests
 
 An Engineer with this core skill must be able to demonstrate how to write readable tests.
@@ -25,3 +26,5 @@ To avoid repetition use of helper methods, common setup/teardown before/after bl
 * Can write tests which follow the AAAT
 * Can describe expected behaviours from the perspective of the user
 * Can refactor poorly written test suite to remove duplication
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/event-plans/README.md
+++ b/event-plans/README.md
@@ -1,8 +1,9 @@
+{% capture content %}
 # Event Plans
 
 ## Made Learning Day
 
-The Made Learning Day format is our oldest 100% learning-focused full day format. 
+The Made Learning Day format is our oldest 100% learning-focused full day format.
 
 The goal of a Made Learning Day is to focus on learning outcomes, unlike hack days or similar.
 
@@ -16,4 +17,5 @@ Made Learning Days can be focused around learning any skill.
 * [Common Lisp](./mld/common-lisp)
 * [Erlang](./mld/erlang)
 * [F#](./mld/fsharp)
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/event-plans/mld/common-lisp.md
+++ b/event-plans/mld/common-lisp.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Common Lisp MLD: Worksheet
 
 **You aren’t expected to finish all these exercises.**
@@ -18,4 +19,5 @@ Build a solution to the [Tennis kata](../../katas/tennis/) in Common Lisp.
 
 - Common Lisp has many dialects. Why do you think that is? What benefit does that provide?
 - Consider how a UI might use your Tennis game implementation. Do you think you could make any improvements?
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/event-plans/mld/erlang.md
+++ b/event-plans/mld/erlang.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Erlang MLD: Worksheet
 
 **You aren’t expected to finish all these exercises.**
@@ -10,7 +11,7 @@ Goto [craigjbass/erlang-koans](https://github.com/craigjbass/erlang-koans) and f
 
 You are expected to practice TDD for this exercise
 
-Create a process that can 
+Create a process that can
 
 * Store a piece of data and assign it a unique key
 * Lookup a piece of data by it’s key
@@ -22,5 +23,5 @@ Create a process that can
 
 * Is your public API easy to use? Any improvements?
 * Is your test suite designed well? How coupled is it to the public API?
-
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/event-plans/mld/facilitators-guide.md
+++ b/event-plans/mld/facilitators-guide.md
@@ -1,9 +1,10 @@
+{% capture content %}
 # Facilitators Guide
 
 ## Introduction Presentation
 
 - Agenda
-- Models of Learning 
+- Models of Learning
   - Comfort - Learning - Panic zone
   - Deliberate Practice
 - Pomodoro Technique
@@ -32,7 +33,7 @@ Figure out target mentor group e.g. if doing a MLD on TDD, this could be all the
 The format is 25 minute pomodoros on a global clock, with 5 minute breaks in between.
 
 - You should enforce that everyone stands up, hands off keyboards.
-- Using loud projected voice to get people's attention. 
+- Using loud projected voice to get people's attention.
   - Feel free to use Japanese words such as Hajime and Yame.
 - Encourage people to mingle and chat about their progress.
 - Allow people to discuss other things too.
@@ -62,5 +63,7 @@ Have a screen ready to make it possible for people to show code.
 
 - This could be to show their favourite feature
 - Could be to show some code
-- Could be to talk about things that they don't like or found surprising. 
-- Could be to get criticism on code written during the day 
+- Could be to talk about things that they don't like or found surprising.
+- Could be to get criticism on code written during the day
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/event-plans/mld/fsharp.md
+++ b/event-plans/mld/fsharp.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # F# MLD: Worksheet
 
 **You aren’t expected to finish all these exercises.**
@@ -16,4 +17,5 @@ Build a solution to the [Tennis kata](../../katas/tennis/) in F#.
 
 - F# is a multi-paradigm language, well-known for it's functional programming features. What benefit does type-inference provide?
 - Consider your Tennis solution. In what ways could you make it more functional?
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/event-plans/mld/gnu-smalltalk.md
+++ b/event-plans/mld/gnu-smalltalk.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # GNU Smalltalk MLD: Worksheet
 
 **You aren’t expected to finish all these exercises.**
@@ -18,4 +19,5 @@ Build a solution to the [Tennis kata](../../katas/tennis/) in GNU Smalltalk.
 
 - GNU Smalltalk is a really old language (first release was in 1972!). What can we learn from such an old programming language?
 - Consider how a UI might use your Tennis game implementation. Do you think you could make any improvements?
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/goals/README.md
+++ b/goals/README.md
@@ -1,16 +1,17 @@
+{% capture content %}
 # Deliberate Learning Goals
 
 In order to do deliberate learning, it's important to:
 
 - set a goal for what it is you are going to learn (it must be **Goal Directed**)
 - get feedback from a mentor (it must include opportunity for **Feedback**)
-- reflect on what you have learned and improve it (you must do **Self-reflection**) 
+- reflect on what you have learned and improve it (you must do **Self-reflection**)
 
-Once you achieve these three things; you will realise that in order to really learn you cannot simply _absorb knowledge_ you must also **create knowledge**. 
+Once you achieve these three things; you will realise that in order to really learn you cannot simply _absorb knowledge_ you must also **create knowledge**.
 
-This new knowledge can be small and discrete, or it can be complex and far reaching. 
+This new knowledge can be small and discrete, or it can be complex and far reaching.
 
-Finally, to really solidify your learning - Mentor others. 
+Finally, to really solidify your learning - Mentor others.
 
 **And remember, you do not need to know everything to be a successful mentor.**
 
@@ -24,7 +25,7 @@ As a high level summary, we will cover the following -
 1. Watch the [introduction to TDD screencast](../screencasts/tennis.md).
 2. (Pair or mob with a mentor on) [code katas](../katas) using [Test Driven Development](../core-skills/tdd/) discipline.
 3. (Pair or mob with a mentor on) subcutaneous acceptance testing, and ATDD discipline.
-4. Explore the three central components Clean Architecture 
+4. Explore the three central components Clean Architecture
   - Use Cases
   - Gateways (Adapter Pattern)
   - Domain Driven Design
@@ -67,4 +68,5 @@ Please feel free to use this list as a guide to help you and your mentors set go
 Our team has put together a set of [Core Skills with associated animal badges](../#recognition), which are [continuously evolving](https://github.com/madetech/learn/issues).
 
 These are designed to enable new joiners deliberately practice skills which are valuable to delivery teams.
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Learning Ideas
 
 No matter how much experience, there is always more to learn or practice.
@@ -33,7 +34,7 @@ It goes without saying, but code katas are meant to be repeated.
 
 Each time, you should focus on honing a particular part of your skill set.
 
-You will pick up new knowledge as you finish workshops and seminars. 
+You will pick up new knowledge as you finish workshops and seminars.
 
 Focus on applying that new knowledge in practice.
 
@@ -75,7 +76,7 @@ Do you need to follow the guide, or can you remember what to do?
 
 ### Shadow others
 
-If you're currently not on a delivery team. 
+If you're currently not on a delivery team.
 If possible, arrange to shadow a team actively developing software.
 
 ### Code Review
@@ -99,5 +100,6 @@ Remember:
 * ATDD your code
 * Refactor relentlessly
 * Put into practice your ever growing knowledge
-* Ask for help when stuck 
-
+* Ask for help when stuck
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/ideas/get-feedback-on-code.md
+++ b/ideas/get-feedback-on-code.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Get feedback on code
 
 ## Find a mentor
@@ -11,4 +12,5 @@ Show & Tell your code at Learn Tech. Ask for constructive feedback.
 ## Wider team
 
 Share your code with the team on slack in an appropriate channel #engineering, #learntech, #python etc.
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/ideas/learn-a-new-language.md
+++ b/ideas/learn-a-new-language.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Learn a new language
 
 We have found that [Koans](../koans) have worked well for us.
@@ -9,4 +10,5 @@ Enabling us to gain a broad understanding of a new language's syntax in a very s
 * What build tool does that community use?
 * What is the most common testing framework in that language?
 * Is there a linting tool used in that language?
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/ideas/learn-how-to-setup-ruby.md
+++ b/ideas/learn-how-to-setup-ruby.md
@@ -1,3 +1,6 @@
+{% capture content %}
 # learn how to setup Ruby
 
 We have [a workshop for this](../workshops/00-Setup-Workshop), which covers setting up a macOS development for Ruby with rbenv.
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/ideas/learn-software-architecture.md
+++ b/ideas/learn-software-architecture.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Learn Software Architecture
 
 A good software architecture keeps options open, allows you to defer decisions about tools and frameworks, and keep the cost of change low.
@@ -22,4 +23,5 @@ Learn Tech is a good opportunity to learn software architecture by practicing al
 * Refactoring (Martin Fowler)
 * Working Effectively with Legacy Code (Michael C. Feathers)
 * Practical Object Oriented Design in Ruby (Sandi Metz)
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/ideas/learn-to-tdd.md
+++ b/ideas/learn-to-tdd.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Learn to TDD
 
 ## Learn the basics
@@ -29,4 +30,5 @@ In the end, you'll want to improve your software design knowledge to unlock the 
 ## Practice
 
 Ultimately, it's all about [practice](./practice-tdd.md).
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/ideas/practice-tdd.md
+++ b/ideas/practice-tdd.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Practice TDD
 
 Once you understand the basics of Test Driven Development, you'll need to practice to gain experience.
@@ -8,7 +9,7 @@ However, the most beneficial practice, is "Deliberate Practice" which must be:
 
 * Goal Directed, and have opportunity for:
 * Feedback, and
-* Self-reflection 
+* Self-reflection
 
 It may be difficult to find opportunity to get all of these things in your every day work.
 
@@ -19,7 +20,7 @@ If that is the case, then you must find other opportunities.
 Practice simple design:
 
 1. Passes its tests
-2. Minimizes duplication (of concepts) 
+2. Minimizes duplication (of concepts)
 3. Maximizes clarity (revealing intent)
 4. Has fewer elements (exactly what you need)
 
@@ -178,7 +179,7 @@ Other primitives
 16. Test – no assert
 17. Test – too many paths
 
-During this session the facilitator is very intrusive. The facilitator is the Benevolent Dictator that cares about good quality code. While coding the facilitator will stop you whenever (s)he spots a coding smell, from the list above. Adding functionalities is forbidden until the pair refactors the smell away. The pair is allowed to add new functionality only when the code smell removal was approved by the facilitator. 
+During this session the facilitator is very intrusive. The facilitator is the Benevolent Dictator that cares about good quality code. While coding the facilitator will stop you whenever (s)he spots a coding smell, from the list above. Adding functionalities is forbidden until the pair refactors the smell away. The pair is allowed to add new functionality only when the code smell removal was approved by the facilitator.
 
 I use post-its on which I write the coding smell, and stick it on the desk of that pair. When the pair has removed the coding smell away I encourage them to rip the post-it with an evil laughter and say “I killed you, evil coding smell!”
 
@@ -203,4 +204,5 @@ See more:
 Object Oriented Programming to Event Driven Development
 
 All the connections between structures are done with events
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/README.md
+++ b/katas/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Katas
 
 * [Bowling](./bowling)
@@ -11,3 +12,5 @@
 * [Test Framework](./test-framework)
 * [Video Store](./video-store)
 * [Mars Rover](./mars-rover)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/bowling/README.md
+++ b/katas/bowling/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Bowling
 
 Create a program, which, given a valid sequence of rolls for one line of American Ten-Pin Bowling, produces the total score for the game. Here are some things that the program will not do:
@@ -19,6 +20,8 @@ Each game, or “line” of bowling, includes ten turns, or “frames” for the
 * If the bowler gets a spare or strike in the last (tenth) frame, the bowler gets to throw one or two more bonus balls, respectively. These bonus throws are taken as part of the same turn. If the bonus throws knock down all the pins, the process does not repeat: the bonus throws are only used to calculate the score of the final frame.
 * The game score is the total of all frame scores.
 
-## References 
+## References
 
 [codingdojo.org](https://codingdojo.org/kata/Bowling/)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/mars-rover/README.md
+++ b/katas/mars-rover/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Mars Rover Kata
 
 You’re part of the team that explores Mars by sending remotely controlled vehicles to the surface of the planet. Develop an API that translates the commands sent from earth to instructions that are understood by the rover.
@@ -19,3 +20,5 @@ You’re part of the team that explores Mars by sending remotely controlled vehi
 
 * [Victor Farcic](https://technologyconversations.com/2014/10/17/java-tutorial-through-katas-mars-rover/)
 * [Kata Log Rocks: Mars Rover](http://kata-log.rocks/mars-rover-kata)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/mumbling/README.md
+++ b/katas/mumbling/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Mumbling Kata
 
 The goal of this kata is to implement the `mumble_letters()` method which takes a string as input and returns a formatted output string. The output string contains sequences of repeating letters with each letter repeated a number of times based on its position in the input string i.e. the 3rd letter in the string is repeated 3 times. Each sequence of repeated letters is separated with a hyphen(-) and the first letter of each sequence is capitalised.
@@ -25,3 +26,5 @@ Note that your `mumble_letters()` implementation should also handle an empty str
 ## References
 
 * [Codewars Mumbling Kata](https://www.codewars.com/kata/mumbling)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/number-to-lcd/README.md
+++ b/katas/number-to-lcd/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Number to LCD
 
 Goal: write a program that displays LCD style numbers.
@@ -11,7 +12,7 @@ Write a program that given a number (with arbitrary number of digits), converts 
  | _| _||_||_ |_   ||_||_|  
  ||_  _|  | _||_|  ||_| _|  
 ```
- 
+
 (each digit is 3 lines high)
 
 Note: Please do *NOT* read the second part before completing the first. Part of the purpose of this kata is to make you  practice refactoring and adapting to changing requirements. [Part two is here](part2.md)
@@ -21,3 +22,5 @@ Note: Please do *NOT* read the second part before completing the first. Part of 
 ## References
 
 [codingdojo.org](https://codingdojo.org/kata/NumberToLCD/)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/number-to-lcd/part2.md
+++ b/katas/number-to-lcd/part2.md
@@ -1,3 +1,4 @@
+{% capture content %}
 ### Part 2
 
 Change your program to support variable width or height of the digits.
@@ -13,3 +14,5 @@ For example for width = 3 and height = 2 the digit 2 will be:
  ___
 
 ```
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/roman-numerals/README.md
+++ b/katas/roman-numerals/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Roman Numerals
 
 Given an integer input, produce output in [Roman Numeral](https://en.wikipedia.org/wiki/Roman_numerals) format.
@@ -17,6 +18,8 @@ Given an integer input, produce output in [Roman Numeral](https://en.wikipedia.o
 * What's the best way to verify your tests are correct?
 * Compare your solutions to others
 
-## Reference 
+## Reference
 
 [codingdojo.org](https://codingdojo.org/kata/RomanNumerals/)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/tennis-refactoring/README.md
+++ b/katas/tennis-refactoring/README.md
@@ -1,5 +1,8 @@
+{% capture content %}
 # Tennis Refactoring
 
 You'll find the starting code for the refactoring kata at [emilybache/Tennis-Refactoring-Kata](https://github.com/emilybache/Tennis-Refactoring-Kata).
 
 Follow the instructions in [Tennis-Refactoring-Kata/README.md](https://github.com/emilybache/Tennis-Refactoring-Kata/blob/master/README.md)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/tennis/README.md
+++ b/katas/tennis/README.md
@@ -1,6 +1,7 @@
+{% capture content %}
 # Tennis
 
-This Kata is about implementing a simple tennis game. 
+This Kata is about implementing a simple tennis game.
 
 Rather than using standard Tennis scoring, **we consider scoring in Wii tennis**, which has a simplified version of tennis, so each set is one game.
 
@@ -10,9 +11,9 @@ The scoring system is as follows:
 
 2. If you have 40 and you win the ball you win the game, however there are special rules.
 
-3. If both have 40 the players are deuce. 
-  - a. If the game is in deuce, the winner of a ball will have advantage and game ball. 
-  - b. If the player with advantage wins the ball they win the game 
+3. If both have 40 the players are deuce.
+  - a. If the game is in deuce, the winner of a ball will have advantage and game ball.
+  - b. If the player with advantage wins the ball they win the game
   - c. If the player without advantage wins they are back at deuce.
 
 ## Alternative description of rules
@@ -28,3 +29,5 @@ The scoring system is as follows:
 ## Reference
 
 [codingdojo.org](https://codingdojo.org/kata/Tennis/)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/test-framework/README.md
+++ b/katas/test-framework/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Test Framework
 
 For this Kata you need to build a test framework from scratch.
@@ -17,4 +18,5 @@ Obviously, you should TDD your solution. (Some creativity required!).
 ## Useful Links
 
 * [Destroy all software: building rspec from scratch](https://www.destroyallsoftware.com/screencasts/catalog/building-rspec-from-scratch)
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/turnstile/README.md
+++ b/katas/turnstile/README.md
@@ -1,4 +1,5 @@
-# Turnstile 
+{% capture content %}
+# Turnstile
 
 ## Finite State Machines
 
@@ -23,3 +24,5 @@ Build a finite state machine from scratch, that replicates the following Finite 
 ![Turnstile FSM](https://yuml.me/diagram/plain;dir:LR/activity/(Locked)-coin[unlock]%3E(Unlocked),%20(Unlocked)-pass[lock]%3E(Locked),%20(Unlocked)-pass[alarm]%3E(Unlocked),%20(Locked)-coin[thanks]%3E(Locked))
 
 Once you have completed that, continue on to part 2 (remember the point is to learn about the impact of changing requirements, so no peeking!) [you can find part 2 here](./part2.md)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/turnstile/part2.md
+++ b/katas/turnstile/part2.md
@@ -1,5 +1,8 @@
+{% capture content %}
 # Part 2
 
 Now extend it to the following states
 
 ![Extended Turnstile FSM](http://yuml.me/dda27fc2.png)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/video-store/README.md
+++ b/katas/video-store/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Video Store
 
 Write a system that can build a `statement`, when given `rentals`.
@@ -34,4 +35,5 @@ You earn 1 frequent renter point no matter the length of the rental.
 # References
 
 This Kata is based upon an example in Martin Fowler's Refactoring book, and is also covered in Episode 3 of [Clean Coders](https://cleancoders.com).
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/katas/word-wrap/README.md
+++ b/katas/word-wrap/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Word Wrap
 
 You write a class called Wrapper, that has a single static function named wrap that takes two arguments, a string, and a column number. The function returns the string, but with line breaks inserted at just the right places to make sure that no line is longer than the column number. You try to break lines at word boundaries.
@@ -7,3 +8,5 @@ Like a word processor, break the line by replacing the last space in a line with
 ## References
 
 [codingdojo.org](https://codingdojo.org/kata/WordWrap/)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/koans/README.md
+++ b/koans/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Koans
 
 The word Koan comes from Zen Practice, there it is used to provoke the "great doubt" and test a student's progress in Zen practice.
@@ -19,3 +20,5 @@ You can usually find Koans for languages by Googling "\<language name\> koans", 
 * [Elm](https://github.com/robertjlooby/elm-koans)
 * [Erlang](https://github.com/patrickgombert/erlang-koans)
 * [Python](https://github.com/gregmalcolm/python_koans)
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/01-The-Power-of-Naming/README.md
+++ b/seminars/01-The-Power-of-Naming/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # The Power of Naming
 
 [Presentation](https://docs.google.com/presentation/d/1-yh9S1I4wdVXJcrOhftJshmlFuDQmq3Rt7vrdfpVvEY/edit?usp=sharing)
@@ -16,3 +17,5 @@
 * Avoid Entertaining Names
 * Avoid Multiple Names for the Same Concept
 * Avoid Multiple Concepts with the Same Name
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/02-Functions/README.md
+++ b/seminars/02-Functions/README.md
@@ -1,8 +1,9 @@
+{% capture content %}
 # Eloquent Functions
 
 [Presentation](https://docs.google.com/presentation/d/139E2O0SShJ8tSKGiLPxlda2QHMpPYG8jEN_abciGONA/edit#slide=id.g1d0b0611da_0_55)
 
-* Short 
+* Short
 * Do one thing
 * One Level of Abstraction
 * Switch statements / polymorphism
@@ -10,3 +11,5 @@
 * Argument objects
 * Side-effects
 * CQS
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/03-Architecture/README.md
+++ b/seminars/03-Architecture/README.md
@@ -1,0 +1,3 @@
+{% capture content %}
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/04-Single-Responsibility-Principle/README.md
+++ b/seminars/04-Single-Responsibility-Principle/README.md
@@ -1,0 +1,3 @@
+{% capture content %}
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/05-Open-Closed-Principle/README.md
+++ b/seminars/05-Open-Closed-Principle/README.md
@@ -1,0 +1,3 @@
+{% capture content %}
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/06-Liskov-Substitution-Principle/README.md
+++ b/seminars/06-Liskov-Substitution-Principle/README.md
@@ -1,0 +1,3 @@
+{% capture content %}
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/07-Interface-Segregation-Principle/README.md
+++ b/seminars/07-Interface-Segregation-Principle/README.md
@@ -1,0 +1,3 @@
+{% capture content %}
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/08-Dependency-Inversion-Principle/README.md
+++ b/seminars/08-Dependency-Inversion-Principle/README.md
@@ -1,0 +1,3 @@
+{% capture content %}
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/seminars/README.md
+++ b/seminars/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Seminar Content
 
 **Note:** These seminars are meant as broad outlines for mentors to deliver, not for mentees.
@@ -8,4 +9,5 @@
 ## References
 
 * [Clean Code](https://www.amazon.co.uk/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882)
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/sparring/README.md
+++ b/sparring/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Sparring
 
 The name comes from Martial Arts; sparring is a form of practice that allows students of a martial art to try out the sum total of all their knowledge in practice.
@@ -12,4 +13,5 @@ While doing these exercises you should retrospect on your previous decisions.
 
 * [Tic Tac Toe](./tic-tac-toe)
 * [Payroll](./payroll)
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/sparring/payroll/README.md
+++ b/sparring/payroll/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Payroll
 
 This is an exercise in Software Design and Changing Requirements.
@@ -32,7 +33,7 @@ Should contain:
 * Total gross pay for tax period (week, month).
 * List of deducted amounts pre-tax incl. rates.
 * List of deducated amounts post-tax incl. what for.
-* The length of the tax period, with start and end dates. 
+* The length of the tax period, with start and end dates.
 
 ## Out of scope
 
@@ -42,3 +43,5 @@ Should contain:
 # Next
 
 Coming soon!
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/sparring/tic-tac-toe/README.md
+++ b/sparring/tic-tac-toe/README.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Tic Tac Toe
 
 This is an exercise in Software Design and Changing Requirements.
@@ -20,9 +21,10 @@ Using the discipline of TDD, build a game of tic tac toe.
 
 3. The first player to get 3 of their marks in a row (up, down, across, or diagonally) is the winner.
 
-4. If all 9 squares are full and no player has 3 marks in a row, the game is over. 
+4. If all 9 squares are full and no player has 3 marks in a row, the game is over.
 
 ## Next
 
 Once you have implemented all the rules here, and are happy with your system's design go [here](./part2.md)
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/sparring/tic-tac-toe/part2.md
+++ b/sparring/tic-tac-toe/part2.md
@@ -1,8 +1,9 @@
+{% capture content %}
 # Part 2
 
 You may have chosen to implement a web interface or a command line user interface, or perhaps another type of UI.
 
-These UIs can be divided into two categories, server-side (e.g. web interface) and client-side (e.g. command line). 
+These UIs can be divided into two categories, server-side (e.g. web interface) and client-side (e.g. command line).
 
 Implement a UI from the opposite category.
 
@@ -15,4 +16,5 @@ Implement a UI from the opposite category.
 ## Next Steps
 
 Once you have implemented your alternative UI, go [here](./part3.md).
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/sparring/tic-tac-toe/part3.md
+++ b/sparring/tic-tac-toe/part3.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Tic Tac Toe: Part 3
 
 Implement the Misère variant of Tic-Tac-Toe
@@ -13,4 +14,5 @@ Implement the Misère variant of Tic-Tac-Toe
 # Part 4
 
 Coming soon!
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,7 +1,8 @@
+{% capture content %}
 # Workshops
 
 * [Setup Workshop](./00-Setup-Workshop) _macOS, terminal, rbenv, ruby_
-* [Command Line Workshop](./01-Command-Line-Workshop) _bash_ 
+* [Command Line Workshop](./01-Command-Line-Workshop) _bash_
 * [Git Workshop](./02-Git-Workshop) _git, bash_
 * [Debugging Workshop](./03-Debugging-Workshop) _ruby, debugging, testing_
 * [Retrospective Planning Workshop](./04-Retrospective-Planning-Workshop) _retrospectives, liberating structures_
@@ -12,4 +13,5 @@
 * [Polymorphism Workshop](./09-Polymorphism-Workshop) _oo, polymorphism_
 * [Database Workshop](./10-Database-Workshop) _relational, sql, database, migration, postgresql_
 * [Docker Workshop](./11-Docker-Workshop) _docker, containerization, docker-compose_
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/videos/README.md
+++ b/videos/README.md
@@ -1,7 +1,9 @@
+{% capture content %}
 # Screencasts
 
 What we have discovered is that observing other practice, is for some skills the easiest way to pick up nuances that would otherwise be missed.
 
 * [An introduction to TDD with the Tennis Kata](./tennis.md) _by Craig J. Bass_ ~TDD, Ruby, Refactoring, RSpec
 * [Build a General Ledger in .NET Core using Clean Architecture](./general-ledger.md) _by Craig J. Bass_ ~ATDD, Clean Architecture, C#, NUnit, Refactoring
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/videos/general-ledger.md
+++ b/videos/general-ledger.md
@@ -1,3 +1,4 @@
+{% capture content %}
 # Build a General Ledger in .NET Core using Clean Architecture
 
 This series is designed to demonstrate using ATDD discipline to build a .NET Core General Ledger using Clean Architecture.
@@ -9,4 +10,5 @@ This series is designed to demonstrate using ATDD discipline to build a .NET Cor
 3. [Part 3 - Second passing acceptance test!](https://drive.google.com/open?id=12lIbf598kHet5m0-LdHstvJVEdzQw4Xv)
 4. [Part 4 - Another Use Case?](https://drive.google.com/open?id=1seqKZi9JRM8BEYsKIPuRM9TV3aiLCfOk)
 5. _coming soon_
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}

--- a/videos/tennis.md
+++ b/videos/tennis.md
@@ -1,7 +1,9 @@
+{% capture content %}
 # Introduction to Test Driven Development (Tennis Kata)
 
 This series is design to be a quick taster to demonstrate the discipline of Test Driven Development.
 
 1. [Part 1 - Introduction](https://drive.google.com/file/d/1WxjDGg8DXm0rwW0bpCRKl1LOrgJJlQ9p/view?usp=sharing)
 2. _coming soon._
-
+{% endcapture %}
+{% include legacy_markdown_container.html content=content %}


### PR DESCRIPTION
What: Use an include to patch legacy markdown  
Why: Legacy markdown no longer presents well in current template  
![image](https://user-images.githubusercontent.com/41294831/59862987-c1037300-937b-11e9-8150-a24eb24a420f.png)
