### PR TITLE
Fix React links

### DIFF
--- a/goals/README.md
+++ b/goals/README.md
@@ -4,13 +4,13 @@ In order to do deliberate learning, it's important to:
 
 - set a goal for what it is you are going to learn (it must be **Goal Directed**)
 - get feedback from a mentor (it must include opportunity for **Feedback**)
-- reflect on what you have learned and improve it (you must do **Self-reflection**) 
+- reflect on what you have learned and improve it (you must do **Self-reflection**)
 
-Once you achieve these three things; you will realise that in order to really learn you cannot simply _absorb knowledge_ you must also **create knowledge**. 
+Once you achieve these three things; you will realise that in order to really learn you cannot simply _absorb knowledge_ you must also **create knowledge**.
 
-This new knowledge can be small and discrete, or it can be complex and far reaching. 
+This new knowledge can be small and discrete, or it can be complex and far reaching.
 
-Finally, to really solidify your learning - Mentor others. 
+Finally, to really solidify your learning - Mentor others.
 
 **And remember, you do not need to know everything to be a successful mentor.**
 
@@ -24,7 +24,7 @@ As a high level summary, we will cover the following -
 1. Watch the [introduction to TDD screencast](../screencasts/tennis.md).
 2. (Pair or mob with a mentor on) [code katas](../katas) using [Test Driven Development](../core-skills/tdd/) discipline.
 3. (Pair or mob with a mentor on) subcutaneous acceptance testing, and ATDD discipline.
-4. Explore the three central components Clean Architecture 
+4. Explore the three central components Clean Architecture
   - Use Cases
   - Gateways (Adapter Pattern)
   - Domain Driven Design
@@ -48,7 +48,7 @@ In order of priority, here is a (non-exhaustive) short-list of some skills that 
 2. [Test Driven Development](../core-skills/tdd/)
 3. Acceptance Testing
 4. Software Architecture
-5. [Web Application Development with React](../core-skills/web-application-development-with-react/)
+5. [Web Application Development with React](../core-skills/react/)
 6. [Frontend Development](../core-skills/frontend-web-development/)
 7. Continuous Delivery / Continuous Integration / DevOps
   - Using a PaaS
@@ -67,4 +67,3 @@ Please feel free to use this list as a guide to help you and your mentors set go
 Our team has put together a set of [Core Skills with associated animal badges](../#recognition), which are [continuously evolving](https://github.com/madetech/learn/issues).
 
 These are designed to enable new joiners deliberately practice skills which are valuable to delivery teams.
-

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ layout: main
 
           <ul>
             <li><a href="/core-skills/tdd/">Test-Driven Development</a></li>
-            <li><a href="/core-skills/web-application-development-with-react/">Web Application Development with React</a></li>
+            <li><a href="/core-skills/react/">Web Application Development with React</a></li>
             <li><a href="/core-skills/frontend-web-development/">Frontend Development</a></li>
           </ul>
         </div>


### PR DESCRIPTION
What: Make React links point to the current React page  
Why: React pages broke when renamed to fit language used