### PR TITLE
Add general layout for design page

### DIFF
--- a/design/index.html
+++ b/design/index.html
@@ -1,0 +1,112 @@
+---
+layout: main
+title: Design
+---
+
+{% capture title %}
+Learn design best practices
+{% endcapture %}
+
+{% capture text %}
+Use these resources to address user needs by focusing on user centred design, research and techniques.
+{% endcapture %}
+
+{% include digital_element_header.html title=title text=text %}
+
+{% capture content %}
+
+<div class="container col-md-10 text-center">
+  <h2>Develop your knowledge</h2>
+  <p class="lead">
+    Resources for improving your research and design skills, lovingly crafted by the team at Made Tech.
+  </p>
+</div>
+
+<div class="row">
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">User research</h3>
+      <p class="card-text">
+        Learn various techniques on how to conduct iterative user research effectively.
+      </p>
+      <a href="/" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">User stories</h3>
+      <p class="card-text">
+        Understand how to frame problems to work towards implementing features.
+      </p>
+      <a href="/" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Personas</h3>
+      <p class="card-text">
+        Create fictional characters to identify what your users needs so your designs are user centred.
+      </p>
+      <a href="/" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Prototyping</h3>
+      <p class="card-text">
+        Develop design thinking skills by regularly testing ideas quickly ensuring constant improvement.
+      </p>
+      <a href="/" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+</div>
+
+<div class="container col-md-10 text-center">
+  <h2>Fundamental design skills</h2>
+  <p class="lead">
+    Coming soon!
+  </p>
+</div>
+
+<div class="row">
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Placeholder 1</h3>
+      <p class="card-text">
+        <i>Coming soon!</i>
+      </p>
+      <a href="/" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Placeholder 2</h3>
+      <p class="card-text">
+        <i>Coming soon!</i>
+      </p>
+      <a href="/" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Placeholder 3</h3>
+      <p class="card-text">
+        <i>Coming soon!</i>
+      </p>
+      <a href="/" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+</div>
+
+<h2>Further reading</h2>
+<ul>
+  <li><a href="/">Link #1</a> - <i>Coming soon</i></li>
+</ul>
+
+{% endcapture %}
+
+{% include digital_element_container.html content=content %}

--- a/design/index.html
+++ b/design/index.html
@@ -29,7 +29,7 @@ Use these resources to address user needs by focusing on user centred design, re
       <p class="card-text">
         Learn various techniques on how to conduct iterative user research effectively.
       </p>
-      <a href="/" class="btn btn-success">Learn more</a>
+      <a href="#" class="btn btn-success">Learn more</a>
     </div>
   </div>
   <div class="col-sm">
@@ -38,7 +38,7 @@ Use these resources to address user needs by focusing on user centred design, re
       <p class="card-text">
         Understand how to frame problems to work towards implementing features.
       </p>
-      <a href="/" class="btn btn-success">Learn more</a>
+      <a href="#" class="btn btn-success">Learn more</a>
     </div>
   </div>
 </div>
@@ -49,7 +49,7 @@ Use these resources to address user needs by focusing on user centred design, re
       <p class="card-text">
         Create fictional characters to identify what your users needs so your designs are user centred.
       </p>
-      <a href="/" class="btn btn-success">Learn more</a>
+      <a href="#" class="btn btn-success">Learn more</a>
     </div>
   </div>
   <div class="col-sm">
@@ -58,7 +58,7 @@ Use these resources to address user needs by focusing on user centred design, re
       <p class="card-text">
         Develop design thinking skills by regularly testing ideas quickly ensuring constant improvement.
       </p>
-      <a href="/" class="btn btn-success">Learn more</a>
+      <a href="#" class="btn btn-success">Learn more</a>
     </div>
   </div>
 </div>
@@ -77,7 +77,7 @@ Use these resources to address user needs by focusing on user centred design, re
       <p class="card-text">
         <i>Coming soon!</i>
       </p>
-      <a href="/" class="btn btn-success">Learn more</a>
+      <a href="#" class="btn btn-success">Learn more</a>
     </div>
   </div>
 
@@ -87,7 +87,7 @@ Use these resources to address user needs by focusing on user centred design, re
       <p class="card-text">
         <i>Coming soon!</i>
       </p>
-      <a href="/" class="btn btn-success">Learn more</a>
+      <a href="#" class="btn btn-success">Learn more</a>
     </div>
   </div>
 
@@ -97,14 +97,14 @@ Use these resources to address user needs by focusing on user centred design, re
       <p class="card-text">
         <i>Coming soon!</i>
       </p>
-      <a href="/" class="btn btn-success">Learn more</a>
+      <a href="#" class="btn btn-success">Learn more</a>
     </div>
   </div>
 </div>
 
 <h2>Further reading</h2>
 <ul>
-  <li><a href="/">Link #1</a> - <i>Coming soon</i></li>
+  <li><a href="#">Link #1</a> - <i>Coming soon</i></li>
 </ul>
 
 {% endcapture %}

--- a/design/index.html
+++ b/design/index.html
@@ -75,7 +75,7 @@ Use these resources to address user needs by focusing on user centred design, re
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Placeholder 1</h3>
       <p class="card-text">
-        <i>Coming soon!</i>
+        <em>Coming soon!</em>
       </p>
       <a href="#" class="btn btn-success">Learn more</a>
     </div>
@@ -85,7 +85,7 @@ Use these resources to address user needs by focusing on user centred design, re
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Placeholder 2</h3>
       <p class="card-text">
-        <i>Coming soon!</i>
+        <em>Coming soon!</em>
       </p>
       <a href="#" class="btn btn-success">Learn more</a>
     </div>
@@ -95,7 +95,7 @@ Use these resources to address user needs by focusing on user centred design, re
     <div class="card-body card-border">
       <h3 class="card-title mt-0">Placeholder 3</h3>
       <p class="card-text">
-        <i>Coming soon!</i>
+        <em>Coming soon!</em>
       </p>
       <a href="#" class="btn btn-success">Learn more</a>
     </div>
@@ -104,7 +104,7 @@ Use these resources to address user needs by focusing on user centred design, re
 
 <h2>Further reading</h2>
 <ul>
-  <li><a href="#">Link #1</a> - <i>Coming soon</i></li>
+  <li><a href="#">Link #1</a> - <em>Coming soon</em></li>
 </ul>
 
 {% endcapture %}


### PR DESCRIPTION
## What

- Add design page in its respective directory.
- Add title HTML element to page
- Add placeholders for skills sections

![](https://user-images.githubusercontent.com/47318342/60011617-0f618c00-9672-11e9-8d56-1b8d77f9ab6c.png)

## Why

This allows us to have a design page as it is a component/discipline of delivering digital services. 