### PR TITLE
Add general layout for product page

### DIFF
--- a/product/index.html
+++ b/product/index.html
@@ -1,0 +1,112 @@
+---
+layout: main
+title: Product
+---
+
+{% capture title %}
+Learn product best practices
+{% endcapture %}
+
+{% capture text %}
+Use these resources to understand what you are delivering to make sure user needs are met.
+{% endcapture %}
+
+{% include digital_element_header.html title=title text=text %}
+
+{% capture content %}
+
+<div class="container col-md-10 text-center">
+  <h2>Maximise your outcomes</h2>
+  <p class="lead">
+    Resources for improving proficiency in delivering made by the team at Made Tech.
+  </p>
+</div>
+
+<div class="row">
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Planning</h3>
+      <p class="card-text">
+        Learn how to make strategic decisions and deliver better using roadmaps.
+      </p>
+      <a href="#" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Product management/ownership</h3>
+      <p class="card-text">
+        Understand how and why product management is important to meeting user needs.
+      </p>
+      <a href="#" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Collaboration</h3>
+      <p class="card-text">
+        Techniques on how to work effectively with your teams ensuring their wellbeing.
+      </p>
+      <a href="#" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Lean product development</h3>
+      <p class="card-text">
+        Learn how decisions based on an iterative approach, prototyping and user feedback affect delivery.
+      </p>
+      <a href="#" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+</div>
+
+<div class="container col-md-10 text-center">
+  <h2>Fundamental product skills</h2>
+  <p class="lead">
+    Coming soon!
+  </p>
+</div>
+
+<div class="row">
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Placeholder 1</h3>
+      <p class="card-text">
+        <em>Coming soon!</em>
+      </p>
+      <a href="#" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Placeholder 2</h3>
+      <p class="card-text">
+        <em>Coming soon!</em>
+      </p>
+      <a href="#" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+
+  <div class="col-sm">
+    <div class="card-body card-border">
+      <h3 class="card-title mt-0">Placeholder 3</h3>
+      <p class="card-text">
+        <em>Coming soon!</em>
+      </p>
+      <a href="#" class="btn btn-success">Learn more</a>
+    </div>
+  </div>
+</div>
+
+<h2>Further reading</h2>
+<ul>
+  <li><a href="#">Link #1</a> - <em>Coming soon</em></li>
+</ul>
+
+{% endcapture %}
+
+{% include digital_element_container.html content=content %}


### PR DESCRIPTION
## What

- Add product page in its respective directory
- Add title HTML element to page
- Add placeholders for skills section.

![product](https://user-images.githubusercontent.com/47318342/60020757-93bf0980-9688-11e9-9212-2c26143360f7.png)

## Why

This allows us to have a product page as it is a component/discipline of delivering digital services.