### PR TITLE
Remove dead links on digital page

### DIFF
--- a/digital/index.html
+++ b/digital/index.html
@@ -58,7 +58,6 @@ Use these resources to empower your teams so that they can focus on delivering o
             Design and research continually informs the way digital
             services are built, ensuring current user needs are met.
           </p>
-          <a href="#" class="btn btn-success">Learn more</a>
         </div>
       </div>
     </div>
@@ -69,7 +68,6 @@ Use these resources to empower your teams so that they can focus on delivering o
           <p class="card-text">
             Digital services must continue to be invested in to meet changing needs.
           </p>
-          <a href="#" class="btn btn-success">Learn more</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
What: Remove remaining 'learn more' buttons on digital page  
Why: They look out of place