### PR TITLE
Add links to product, design and tech on digital page.

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,9 +2,16 @@
 ---
 @charset "UTF-8";
 
-.DeliveryImage, .ProductImage, .DesignImage, .TechnologyImage {
+.DeliveryImage, .ProductImage, .DesignImage {
   width: 500px;
   max-width: 100%;
+}
+
+.TechnologyImage {
+  width: 500px;
+  max-width: 100%;
+  height: 325px;
+  max-height: 100%;
 }
 
 .container img {

--- a/digital/index.html
+++ b/digital/index.html
@@ -115,6 +115,7 @@ Use these resources to empower your teams so that they can focus on delivering o
           in order to meet user needs. This will empower teams to maximise
           outcomes and impact.
         </p>
+        <a href="/product" class="btn btn-success btn-sm">Learn more</a>
       </div>
       <div class="col-md-6">
         <img src="images/product.jpg" alt="Planning meeting" class="ProductImage">
@@ -135,6 +136,7 @@ Use these resources to empower your teams so that they can focus on delivering o
           Digital services must be designed with users in mind alongside
           iterative user research, consistently testing designs using prototypes.
         </p>
+        <a href="/design" class="btn btn-success btn-sm">Learn more</a>
       </div>
     </div>
     <div class="row my-3">
@@ -149,6 +151,7 @@ Use these resources to empower your teams so that they can focus on delivering o
           Digital services are simple and meet user needs. Risk of change is
           reduced as digital services are reliable and scalable.
         </p>
+        <a href="/technology" class="btn btn-success btn-sm">Learn more</a>
       </div>
       <div class="col-md-6">
         <img src="images/technology.jpg" alt="Software engineers pairing" class="TechnologyImage">


### PR DESCRIPTION
## What

- Add links to product, design and technology pages in each respective section
- Update CSS for technology image so buttons are aligned accordingly
- Buttons are the same size as on homepage

![digital](https://user-images.githubusercontent.com/47318342/60249321-87bb8d80-98bc-11e9-8b93-801f8ea32773.png)

## Why

- We want to make sure pages are easily accessible from the digital page as product, design and technology are disciplines of delivering digital services
- Button sizes are matching the ones on the home page to ensure consistency