### PR TITLE
Remove unnecessary padding for cards on digital page.

### DIFF
--- a/digital/index.html
+++ b/digital/index.html
@@ -33,7 +33,7 @@ Use these resources to empower your teams so that they can focus on delivering o
     <div class="col-sm-6">
       <div class="card card-border">
         <div class="card-body">
-          <h3 class="card-title">User-centred design and technology</h3>
+          <h3 class="card-title mt-0">User-centred design and technology</h3>
           <p class="card-text">
             Focusing on user needs ensures that useful software is delivered, maximising outcomes.
           </p>
@@ -43,7 +43,7 @@ Use these resources to empower your teams so that they can focus on delivering o
     <div class="col-sm-6">
       <div class="card card-border">
         <div class="card-body">
-          <h3 class="card-title">Product, design and technology</h3>
+          <h3 class="card-title mt-0">Product, design and technology</h3>
           <p class="card-text">
             Bringing together product, design and technology ensures that
             digital services are viable, desirable and feasible.
@@ -54,7 +54,7 @@ Use these resources to empower your teams so that they can focus on delivering o
     <div class="col-sm-6">
       <div class="card card-border">
         <div class="card-body">
-          <h3 class="card-title">Continuous discovery and development</h3>
+          <h3 class="card-title mt-0">Continuous discovery and development</h3>
           <p class="card-text">
             Design and research continually informs the way digital
             services are built, ensuring current user needs are met.
@@ -65,7 +65,7 @@ Use these resources to empower your teams so that they can focus on delivering o
     <div class="col-sm-6">
       <div class="card card-border">
         <div class="card-body">
-          <h3 class="card-title">Reliable and maintainable services</h3>
+          <h3 class="card-title mt-0">Reliable and maintainable services</h3>
           <p class="card-text">
             Digital services must continue to be invested in to meet changing needs.
           </p>


### PR DESCRIPTION
## What

- Removed extra padding on cards for the digital page.

### Before:
<img width="1145" alt="olddigital" src="https://user-images.githubusercontent.com/47318342/60251534-999f2f80-98c0-11e9-9b57-dec18ce5d078.png">

### After:
<img width="1136" alt="newdigital" src="https://user-images.githubusercontent.com/47318342/60251544-a02da700-98c0-11e9-99cc-70cceecfbead.png">

## Why

-  We can keep consistency and not have any extra padding.