### PR TITLE
Remove links to non-existent article links.

### DIFF
--- a/articles/cost-of-delay.md
+++ b/articles/cost-of-delay.md
@@ -1,15 +1,10 @@
 # Cost of Delay
 
-**Counterpoint:** [Late Start Benefits](./late-start-benefits.md)
+**Counterpoint:** Late Start Benefits
 
 **Blogs:**
 
 - [Made Tech: Cost of Delay](https://www.madetech.com/blog/cost-of-delay)
-
-**Related:**
-
-- [Sunk Costs](./sunk-costs.md)
-- [WSJF](./weighted-shortest-job-first.md)
 
 ## Definition
 
@@ -21,7 +16,7 @@ It is the difference between the value that would be available if a work item we
 
 In reality, it is rare to be able to calculate both the Value and Cost (and therefore also Cost of Delay), so we estimate them.
 
-Teams can use Cost of Delay estimation to prioritise and schedule work items as part of [WSJF](./weighted-shortest-job-first.md) priortisation. 
+Teams can use Cost of Delay estimation to prioritise and schedule work items as part of WSJF priortisation. 
 
 There are a number of standard plots to Cost vs Time on a graph, here are some described with examples.
 


### PR DESCRIPTION
## What

- Remove dead links on Cost of Delay page

## Why 

- Links should be accessible and not broken