### PR TITLE
Add link to BuggyProject

### DIFF
--- a/guides/03-Debugging/README.md
+++ b/guides/03-Debugging/README.md
@@ -38,7 +38,7 @@ Use a disciplined approach - ask yourself if you've made an assumption, and test
 
 ## 2.1 Understand and get it running
 
-Open "BuggyProject" up in a text editor
+Open "[BuggyProject](https://github.com/madetech/learn/tree/master/guides/03-Debugging/BuggyProject)" up in a text editor
 
 Read the contents of the project and understand it's purpose. _Hint: start with the tests._
 


### PR DESCRIPTION
It isn't immediately obvious where the reader can obtain a copy of the BuggyProject when reading this guide.