### PR TITLE
fix display for hedgehog

### DIFF
--- a/core-skills/react/README.md
+++ b/core-skills/react/README.md
@@ -40,7 +40,7 @@ or one that already exists, see: [https://github.com/toddmotto/public-apis](http
 ## Mark Scheme
 
 {% capture hedgehog_description %}
-Learning the fundamentals - How not to hurt yourself with React
+#### Learning the fundamentals - How not to hurt yourself with React
 
 #### Application
 


### PR DESCRIPTION
## What?
The hedgehog subtitle wasn't appearing as an `<h4>` so it looked a little
odd on the page. Fixed by amending the markdown.

## Screenshots
### Before 
<img width="665" alt="Screenshot 2019-11-08 at 14 09 59" src="https://user-images.githubusercontent.com/47317567/68483977-5ffa1000-0234-11ea-9627-0f9ee7bb2ffe.png">

### After
<img width="758" alt="Screenshot 2019-11-08 at 14 29 43" src="https://user-images.githubusercontent.com/47317567/68483986-65eff100-0234-11ea-8f7c-03e6c4c03a1a.png">
