### PR TITLE
add link to tdd dragon repo

### DIFF
--- a/core-skills/tdd/README.md
+++ b/core-skills/tdd/README.md
@@ -106,7 +106,7 @@ You will need to TDD a feature which interacts with a remote service of your cho
 {% include assessment_container.html name="Wolf" description=wolf_description img="./wolf.jpg" %}
 
 {% capture dragon_description %}
-Review, refactor and improve an existing test suite.
+Review, refactor and improve an [existing test suite](https://github.com/madetech/core-skill-tdd/tree/master/ruby-chirper).
 
 - Can identify smells within the sample apps test code.
   - Required - Can list and explain three valid smells per the invigilator's guide.


### PR DESCRIPTION
## What?
The dragon core skill mentioned improving an existing test suite, most people taking the core skill use the chirper repo so added a link to it to make it easier to get to.

## Screenshots
### Before 
<img width="538" alt="Screenshot 2019-11-22 at 14 03 10" src="https://user-images.githubusercontent.com/47317567/69433659-e71aae00-0d33-11ea-9adb-992e0e581261.png">

### After
<img width="545" alt="Screenshot 2019-11-22 at 14 03 30" src="https://user-images.githubusercontent.com/47317567/69433672-eaae3500-0d33-11ea-8fc3-87309cc1d046.png">
