### PR TITLE
stop floating footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,7 +63,7 @@
     </div>
   </header>
 
-  <main class="container">
+  <main class="container container-fullHeight">
     <div class="row">
       <div class="col-md-8 offset-md-2">
         {{ content }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -99,3 +99,7 @@ details > summary {
     margin-right: 10%;
   }
 }
+
+.container-fullHeight {
+  min-height: calc(100vh - 205px);
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -101,5 +101,5 @@ details > summary {
 }
 
 .container-fullHeight {
-  min-height: calc(100vh - 205px);
+  min-height: calc(100vh - 205px); // 205px -> Height of the header-nav, Header, and Footer
 }


### PR DESCRIPTION
Pages with content that has a shorter height than the view resulted in a floating footer. Added a minimum height to the <main> in order to ensure that the total page height is always 100vh